### PR TITLE
Issue#53: Enable user to set two different thresholds for scrolling in and out of view.

### DIFF
--- a/dist/scroll-out.js
+++ b/dist/scroll-out.js
@@ -148,6 +148,15 @@ var ScrollOut = (function () {
               var intersectY = visibleY === 1 ? 0 : sign(offsetY - clientOffsety);
               var viewportX = clamp((clientOffsetX - (elementWidth / 2 + offsetX - clientWidth / 2)) / (clientWidth / 2), -1, 1);
               var viewportY = clamp((clientOffsety - (elementHeight / 2 + offsetY - clientHeight / 2)) / (clientHeight / 2), -1, 1);
+              //Check if element is moving in or out of focus and apply correct threshold if thresholdInOut is set
+              if (opts.thresholdInOut) {
+                  if (ctx.visibleY < visibleY || ctx.visibleX < visibleX) {
+                      opts.threshold = opts.thresholdInOut["in"];
+                  }
+                  else {
+                      opts.threshold = opts.thresholdInOut.out;
+                  }
+              }
               var visible = void 0;
               if (opts.offset) {
                   visible = unwrap(opts.offset, element, ctx, doc) <= clientOffsety ? 1 : 0;

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,6 +101,15 @@ export default function (opts: IScrollOutOptions) {
         1
       );
 
+      //Check if element is moving in or out of focus and apply correct threshold if thresholdInOut is set
+      if(opts.thresholdInOut) {
+        if(ctx.visibleY < visibleY || ctx.visibleX < visibleX) {
+          opts.threshold = opts.thresholdInOut.in;
+        } else {
+          opts.threshold = opts.thresholdInOut.out;
+        }
+      }
+
       let visible: 0 | 1;
       if (opts.offset) {
         visible = unwrap(opts.offset, element, ctx, doc) <= clientOffsety ? 1 : 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface IScrollOutOptions {
   scrollingElement?: Node | string;
   targets?: Node | NodeList | Node[] | string;
   threshold?: ValueOrProvider<number>;
+  thresholdInOut?: ThresholdInOut;
 }
 
 export type TargetEventCallback = (el: HTMLElement, ctx: ElementContext, doc: HTMLElement) => void;
@@ -75,4 +76,9 @@ export interface ScrollOut {
   index(): void;
   teardown(): void;
   update(): void;
+}
+
+export interface ThresholdInOut {
+  in: number,
+  out: number,
 }


### PR DESCRIPTION
I know this issue is quite old, but I needed that exact same feature when using scroll-out, so I had a go at it.

Basically I implemented a new prop called **thresholdInOut** that takes in two thresholds, one for in, one for out.

I tested it on some examples and was happy with the results, if there is anything wrong with it please let me know.